### PR TITLE
[Github Pod Metrics] Add language

### DIFF
--- a/db/migrations/003_add_pod_language_to_github_pod_metrics.rb
+++ b/db/migrations/003_add_pod_language_to_github_pod_metrics.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:github_pod_metrics) do
+      add_column :language, String, :null => true
+    end
+  end
+end

--- a/db/schema.txt
+++ b/db/schema.txt
@@ -90,23 +90,6 @@ owners
 | updated_at | 1114 | "timestamp without time zone" | nil                                  | true       | false       | :datetime | nil          |
 +------------+------+-------------------------------+--------------------------------------+------------+-------------+-----------+--------------+
 
-github_pod_metrics
-+--------------------+------+-------------------------------+--------------------------------------------------+------------+-------------+-----------+--------------+
-| name               | oid  | db_type                       | default                                          | allow_null | primary_key | type      | ruby_default |
-+--------------------+------+-------------------------------+--------------------------------------------------+------------+-------------+-----------+--------------+
-| id                 | 23   | "integer"                     | "nextval('github_pod_metrics_id_seq'::regclass)" | false      | true        | :integer  | nil          |
-| pod_id             | 23   | "integer"                     | nil                                              | false      | false       | :integer  | nil          |
-| subscribers        | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
-| stargazers         | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
-| forks              | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
-| contributors       | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
-| open_issues        | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
-| open_pull_requests | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
-| not_found          | 23   | "integer"                     | "0"                                              | true       | false       | :integer  | 0            |
-| created_at         | 1114 | "timestamp without time zone" | nil                                              | true       | false       | :datetime | nil          |
-| updated_at         | 1114 | "timestamp without time zone" | nil                                              | true       | false       | :datetime | nil          |
-+--------------------+------+-------------------------------+--------------------------------------------------+------------+-------------+-----------+--------------+
-
 commits
 +----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
 | name                       | oid  | db_type                       | default                               | allow_null | primary_key | type      | ruby_default |
@@ -122,6 +105,24 @@ commits
 | renamed_file_during_import | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
 | deleted_file_during_import | 16   | "boolean"                     | "false"                               | true       | false       | :boolean  | false        |
 +----------------------------+------+-------------------------------+---------------------------------------+------------+-------------+-----------+--------------+
+
+github_pod_metrics
++--------------------+------+-------------------------------+--------------------------------------------------+------------+-------------+-----------+--------------+
+| name               | oid  | db_type                       | default                                          | allow_null | primary_key | type      | ruby_default |
++--------------------+------+-------------------------------+--------------------------------------------------+------------+-------------+-----------+--------------+
+| id                 | 23   | "integer"                     | "nextval('github_pod_metrics_id_seq'::regclass)" | false      | true        | :integer  | nil          |
+| pod_id             | 23   | "integer"                     | nil                                              | false      | false       | :integer  | nil          |
+| subscribers        | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
+| stargazers         | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
+| forks              | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
+| contributors       | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
+| open_issues        | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
+| open_pull_requests | 23   | "integer"                     | nil                                              | true       | false       | :integer  | nil          |
+| not_found          | 23   | "integer"                     | "0"                                              | true       | false       | :integer  | 0            |
+| created_at         | 1114 | "timestamp without time zone" | nil                                              | true       | false       | :datetime | nil          |
+| updated_at         | 1114 | "timestamp without time zone" | nil                                              | true       | false       | :datetime | nil          |
+| language           | 25   | "text"                        | nil                                              | true       | false       | :string   | nil          |
++--------------------+------+-------------------------------+--------------------------------------------------+------------+-------------+-----------+--------------+
 
 schema_info_metrics
 +---------+-----+-----------+---------+------------+-------------+----------+--------------+

--- a/lib/metrics/github.rb
+++ b/lib/metrics/github.rb
@@ -50,7 +50,8 @@ module Metrics
         :forks => repo.forks_count,
         :contributors => client.repos.contributors.size,
         :open_issues => repo.open_issues_count,
-        :open_pull_requests => client.pull_requests.all.size
+        :open_pull_requests => client.pull_requests.all.size,
+        :language => repo.language
       }
     end
 

--- a/spec/functional/api/v1/pods_spec.rb
+++ b/spec/functional/api/v1/pods_spec.rb
@@ -14,6 +14,7 @@ describe MetricsApp, '/api/v1/pods/:name' do
       :contributors => 30,
       :open_issues => 227,
       :open_pull_requests => 30,
+      :language => 'Objective-C',
       :not_found => 1,
       :created_at => '2014-06-11 16:40:13 UTC',
       :updated_at => nil
@@ -31,6 +32,7 @@ describe MetricsApp, '/api/v1/pods/:name' do
         'contributors' => 30,
         'open_issues' => 227,
         'open_pull_requests' => 30,
+        'language' => 'Objective-C',
         'created_at' => '2014-06-11 16:40:13 UTC',
         'updated_at' => nil
       }
@@ -51,6 +53,7 @@ describe MetricsApp, '/api/v1/pods/:name' do
         'open_issues' => 227,
         'open_pull_requests' => 30,
         'not_found' => 1,
+        'language' => 'Objective-C',
         'created_at' => '2014-06-11 16:40:13 UTC',
         'updated_at' => nil
       }


### PR DESCRIPTION
I decided to use the `language` field in the response of `/repos/{name}/{repo}`. Both because it means not making an extra call to `/repos/{name}/{repo}/languages` and because I trust Github can figure out the majority language of a repo better than me. 

Closes: https://github.com/CocoaPods/metrics.cocoapods.org/issues/18
Sister PR: https://github.com/CocoaPods/Humus/pull/6
Regarding the migration I was unsure if I should also add the migration in this repository, but if I understand it correctly the migrations in this repo have been deprecated?(shouldn't they be removed in that case)

Also I didn't not get trunk setup so I haven't actually ran the specs and I still need to add one for the language related changes I guess