### PR TITLE
Reduce logging output

### DIFF
--- a/lib/metrics/github.rb
+++ b/lib/metrics/github.rb
@@ -79,7 +79,6 @@ module Metrics
     end
 
     def handle_update_error(e, pod)
-      METRICS_APP_LOGGER.error e
       case e.message
       when /404 Not Found/
         not_found(pod)
@@ -87,6 +86,8 @@ module Metrics
         headers = ::Github::Response::Header.new response_headers: e.http_headers
         raise build_rate_limit_error(headers)
       else
+        # Only log out when there's an unexpected error, vs expected errors
+        METRICS_APP_LOGGER.error e
         raise
       end
     end


### PR DESCRIPTION
Our logs were getting excessive, they are mostly logging out for errors that we are aware of and is a part of the flow of the app. Now we only log out for surprises.

![screen shot 2015-11-09 at 2 42 40 pm](https://cloud.githubusercontent.com/assets/49038/11044503/450fe40e-86f0-11e5-9a9c-b146351a37be.png)
