### PR TITLE
add a context to the ratelimit error

### DIFF
--- a/lib/metrics/updater.rb
+++ b/lib/metrics/updater.rb
@@ -44,7 +44,7 @@ module Metrics
       else
         raise e
       end
-    rescue RateLimitError => e
+    rescue Metrics::Github::RateLimitError => e
       if e.resets_at
         sleep_time = (e.resets_at - Time.now.to_i) + 10
         sleep sleep_time if sleep_time > 0


### PR DESCRIPTION
We are seeing errors when getting rate limited, but our error handling wasn't taking the scope of the error correctly. This _should_ fix that.

```
2015-11-10T17:20:38.313187+00:00 app[web.1]: /app/lib/metrics/updater.rb:47:in `rescue in update': uninitialized constant Metrics::Updater::RateLimitError (NameError)
2015-11-10T17:20:38.313191+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:38:in `update'
2015-11-10T17:20:38.313192+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:29:in `block (2 levels) in run_child_process'
2015-11-10T17:20:38.313193+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:21:in `loop'
2015-11-10T17:20:38.313194+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:21:in `block in run_child_process'
2015-11-10T17:20:38.313197+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:20:in `run_child_process'
2015-11-10T17:20:38.313195+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:20:in `fork'
2015-11-10T17:20:38.313198+00:00 app[web.1]: 	from /app/lib/metrics/updater.rb:15:in `start'
2015-11-10T17:20:38.313198+00:00 app[web.1]: 	from /app/updater.rb:7:in `<top (required)>'
2015-11-10T17:20:38.313199+00:00 app[web.1]: 	from /app/config.ru:5:in `require'
2015-11-10T17:20:38.313200+00:00 app[web.1]: 	from /app/config.ru:5:in `block in <main>'
2015-11-10T17:20:38.313201+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/rack-1.6.0/lib/rack/builder.rb:55:in `instance_eval'
2015-11-10T17:20:38.313201+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/rack-1.6.0/lib/rack/builder.rb:55:in `initialize'
2015-11-10T17:20:38.313202+00:00 app[web.1]: 	from /app/config.ru:1:in `new'
2015-11-10T17:20:38.313203+00:00 app[web.1]: 	from /app/config.ru:1:in `<main>'
2015-11-10T17:20:38.313205+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/rack/adapter/loader.rb:33:in `eval'
2015-11-10T17:20:38.313206+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/rack/adapter/loader.rb:33:in `load'
2015-11-10T17:20:38.313207+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/rack/adapter/loader.rb:42:in `for'
2015-11-10T17:20:38.313208+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/thin/controllers/controller.rb:170:in `load_adapter'
2015-11-10T17:20:38.313211+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/thin/runner.rb:199:in `run_command'
2015-11-10T17:20:38.313208+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/thin/controllers/controller.rb:74:in `start'
2015-11-10T17:20:38.313212+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/lib/thin/runner.rb:155:in `run!'
2015-11-10T17:20:38.313212+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/gems/thin-1.6.2/bin/thin:6:in `<top (required)>'
2015-11-10T17:20:38.313213+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/bin/thin:23:in `load'
2015-11-10T17:20:38.313215+00:00 app[web.1]: 	from /app/vendor/bundle/ruby/2.1.0/bin/thin:23:in `<main>'
```

